### PR TITLE
new feature to add flecs to the PE file export table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Cargo.lock
 
 .vscode
+.idea
 flamegraph.svg
 
 *.o

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ criterion = "0.5"
 
 [features]
 export_bindings = ["flecs-sys/export_bindings"]
+enable_export_symbols = ["flecs-sys/enable_export_symbols"]
 
 [[example]]
 name = "entity_basics"

--- a/flecs-sys/Cargo.toml
+++ b/flecs-sys/Cargo.toml
@@ -19,3 +19,4 @@ regex = "1.8"
 
 [features]
 export_bindings = []
+enable_export_symbols = [] # uses this feature with a Cdylib or a bin with the flag -Zexport-executable-symbols

--- a/flecs-sys/build.rs
+++ b/flecs-sys/build.rs
@@ -66,10 +66,16 @@ fn main() {
 	#[cfg(feature = "export_bindings")]
 	generate_bindings();
 
+	#[cfg(not(feature = "enable_export_symbols"))]
+	const FLECS_EXPORT: &str = "flecs_STATIC";
+	#[cfg(feature = "enable_export_symbols")]
+	const FLECS_EXPORT: &str = "flecs_EXPORTS";
+
 	// Compile flecs C right into our Rust crate
 	cc::Build::new()
 		.warnings(true)
 		.extra_warnings(true)
+		.define(FLECS_EXPORT, None)
 		.define("NDEBUG", None)
 		// .flag("-flto")			// no impact on Arm. Perhaps useful to other archs.
 		// .flag("-fuse-ld=lld")	// not available on MacOS/Arm

--- a/flecs-sys/flecs.h
+++ b/flecs-sys/flecs.h
@@ -1,5 +1,5 @@
 // Comment out this line when using as DLL
-#define flecs_STATIC
+//#define flecs_STATIC //this line must be commented each time flecs is updated
 /**
  * @file flecs.h
  * @brief Flecs public API.


### PR DESCRIPTION
Now, Flecs can be hosted in an executable file and loaded as a .dll/.so file from another binding !